### PR TITLE
Set default `capture` to `false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
 
 exports.bind = function(el, type, fn, capture){
   if (el.addEventListener) {
-    el.addEventListener(type, fn, capture);
+    el.addEventListener(type, fn, capture || false);
   } else {
     el.attachEvent('on' + type, fn);
   }
@@ -32,7 +32,7 @@ exports.bind = function(el, type, fn, capture){
 
 exports.unbind = function(el, type, fn, capture){
   if (el.removeEventListener) {
-    el.removeEventListener(type, fn, capture);
+    el.removeEventListener(type, fn, capture || false);
   } else {
     el.detachEvent('on' + type, fn);
   }


### PR DESCRIPTION
Portability is improved by ensuring that if the `capture` argument is
missing, it's set to `false` by default. Older implementations require
the third argument to be set in add/removeEventListener.

Fixes #4
