### PR TITLE
Normalize event handler in IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ exports.bind = function(el, type, fn, capture){
   if (el.addEventListener) {
     el.addEventListener(type, fn, capture);
   } else {
-    el.attachEvent('on' + type, fn);
+    el.attachEvent('on' + type, function(){
+      fn.call(el, window.event);
+    });
   }
   return fn;
 };
@@ -34,7 +36,9 @@ exports.unbind = function(el, type, fn, capture){
   if (el.removeEventListener) {
     el.removeEventListener(type, fn, capture);
   } else {
-    el.detachEvent('on' + type, fn);
+    el.detachEvent('on' + type, function(){
+      fn.call(el, window.event);
+    });
   }
   return fn;
 };


### PR DESCRIPTION
`attachEvent` invokes the event handler in context of window object. To
ensure additional consistency with `addEventListener`, make sure that
`attachEvent` always invokes the event handler in the context of the
element to which the listener is bound.

The `window.event` object is passed as the first argument to the handler
function to ensure that it has the proper event object. `attachEvent`
only makes the event object accessible via the global `window.event`
property; it doesn't pass the event to the handler function.

As far as I understand, a consequence of this change is the creation of
a memory leak (due to the circular reference) in IE 6/7. I believe IE 8
meant to have fixed this issue.
