### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "event",
     "events"
   ],
+  "license": "MIT",
   "component": {
     "scripts": {
       "event/index.js": "index.js"


### PR DESCRIPTION
So it displays without an * in tools like:
https://www.npmjs.com/package/license-checker